### PR TITLE
Dockerfile:  update to use maestro-base-alp8-jdk8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Dockerfile for ZooKeeper
 
-FROM quay.io/signalfuse/maestro-base:alp-3.4-jdk8
+FROM quay.io/signalfuse/maestro-base:alp-3.8-jdk8
 MAINTAINER Maxime Petazzoni <max@signalfx.com>
 
 # Get latest stable release of ZooKeeper


### PR DESCRIPTION
Uses latest alpine with latest security updates.
Includes jdk8 update 181