### PR TITLE
Update zookeeper-3.5.4-beta to zookeeper-3.5.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,12 +4,12 @@ FROM quay.io/signalfuse/maestro-base:alp-3.8-jdk8
 MAINTAINER Maxime Petazzoni <max@signalfx.com>
 
 # Get latest stable release of ZooKeeper
-RUN wget -q -O - https://www.apache.org/dist/zookeeper/zookeeper-3.5.4-beta/zookeeper-3.5.4-beta.tar.gz \
+RUN wget -q -O - https://www.apache.org/dist/zookeeper/zookeeper-3.5.5/apache-zookeeper-3.5.5.tar.gz \
   | tar -C /opt -xz
 
-ADD run.py /opt/zookeeper-3.5.4-beta/.docker/
-ADD entrypoint.sh /opt/zookeeper-3.5.4-beta/.docker/
+ADD run.py /opt/apache-zookeeper-3.5.5/.docker/
+ADD entrypoint.sh /opt/apache-zookeeper-3.5.5/.docker/
 
-WORKDIR /opt/zookeeper-3.5.4-beta/
+WORKDIR /opt/apache-zookeeper-3.5.5/
 ENTRYPOINT [".docker/entrypoint.sh"]
-CMD ["python", "/opt/zookeeper-3.5.4-beta/.docker/run.py"]
+CMD ["python", "/opt/apache-zookeeper-3.5.5/.docker/run.py"]


### PR DESCRIPTION
**Summary**

This PR aims to update Zookeper version from zookeeper-3.5.4-beta to zookeeper-3.5.5 due to currently zookeeper-3.5.4-beta is not existing anymore.