### PR TITLE
Add RUN_CMD env var to container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,5 +11,9 @@ ADD run.py /opt/apache-zookeeper-3.5.5/.docker/
 ADD entrypoint.sh /opt/apache-zookeeper-3.5.5/.docker/
 
 WORKDIR /opt/apache-zookeeper-3.5.5/
+
+# Keep RUN_CMD in sync with ENTRYPOINT and CMD or just use the wrapped shell with ENV VAR
+ENV RUN_CMD=".docker/entrypoint.sh python /opt/apache-zookeeper-3.5.5/.docker/run.py"
+# CMD ["sh", "-c", "$RUN_CMD"]
 ENTRYPOINT [".docker/entrypoint.sh"]
 CMD ["python", "/opt/apache-zookeeper-3.5.5/.docker/run.py"]


### PR DESCRIPTION
Add RUN_CMD env var so that we can potentially hook the startup process from helm charts (as needed for istio)