### PR TITLE
Update client port env var name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ seed the service's configuration:
     which will be used for looking up links and ports informations from the
     other environment variables. For this, the name is uppercased and
     non-alphanumeric characters are replaced by underscores.
-  - `<SERVICE_NAME>_<CONTAINER_NAME>_CLIENT_PORT`, which controls the
+  - `<SERVICE_NAME>_<CONTAINER_NAME>_CLIENT_INTERNAL_PORT`, which controls the
     `clientPort` configuration setting. Defaults to 2181;
   - `<SERVICE_NAME>_<CONTAINER_NAME>_PEER_PORT`, which is used as the
     peer port specified in the server list for this node (and the


### PR DESCRIPTION
I faced a startup error when setting up a local minimal zookeeper from this image. Apparently, `run.py` uses `get_port` for the zookeeper client port, which expects the env var name to include `_INTERNAL` in its name. Worked fine afterwards. I checked the other ports just in case, they are all obtained using `get_specific_port`, so this is the only problematic one.

See also: https://github.com/signalfx/maestro-ng/commit/fe2f7a015a3422cf910e705f93ea5172f0d5a531