### PR TITLE
Add default value for zookeeper client port

### DIFF
--- a/run.py
+++ b/run.py
@@ -61,7 +61,7 @@ def build_node_repr(name):
         get_specific_host(DISCOVERY_SERVICE_NAME, name),
         get_specific_port(DISCOVERY_SERVICE_NAME, name, 'peer'),
         get_specific_port(DISCOVERY_SERVICE_NAME, name, 'leader_election') or get_specific_port(DISCOVERY_SERVICE_NAME, name, 'election'),
-        get_specific_port(DISCOVERY_SERVICE_NAME, name, 'client'),
+        get_specific_port(DISCOVERY_SERVICE_NAME, name, 'client', 2181),
     )
 
 

--- a/run.py
+++ b/run.py
@@ -42,7 +42,7 @@ conf = {
     'reconfigEnabled': 'false',
     'dataDir': ZOOKEEPER_DATA_DIR,
     'quorumListenOnAllIPs': True,
-    'clientPort': get_port('client'),
+    'clientPort': get_port('client', 2181),
     'autopurge.snapRetainCount':
         int(os.environ.get('MAX_SNAPSHOT_RETAIN_COUNT', 10)),
     'autopurge.purgeInterval':


### PR DESCRIPTION
The README for says that the client port should default to `2181`, but the container fails to start if the `<SERVICE_NAME>_<CONTAINER_NAME>_CLIENT_INTERNAL_PORT` env var is not provided. This behavior was introduced in #23 and apparently was not intentional.